### PR TITLE
#1 use the counter probability for the reordering

### DIFF
--- a/packetsAndErrors/errorDetector.go
+++ b/packetsAndErrors/errorDetector.go
@@ -121,7 +121,8 @@ func CalculateReorderRate(numberOfReorderedPackets int64, packetTuples []*Packet
 	}
 
 	// calculate probability for reorder
-	return float64(numberOfReorderedPackets) / float64(packetsWithoutLostOrReorder)
+	// use the counter probability to match netem
+	return 1 - (float64(numberOfReorderedPackets) / float64(packetsWithoutLostOrReorder))
 }
 
 // CalculateMarkovRates is a public function to calculate the probabilities for the simulation of loss


### PR DESCRIPTION
To match the probability for reorder used by netem the counter probability should be returned due to different reorder definitions.

This resolves #1